### PR TITLE
Check if template_path exitsts

### DIFF
--- a/django_template_finder_view/__init__.py
+++ b/django_template_finder_view/__init__.py
@@ -29,7 +29,10 @@ class TemplateFinder(TemplateView):
 
         index = join(template_path, 'index.html')
         template = join(template_path + '.html')
-        if self.__template_exists__(template):
+        if (
+                self.__template_exists__(template) or
+                self.__template_exists__(template_path)
+        ):
             return template
         elif self.__template_exists__(index):
             return index

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='django-template-finder-view',
-    version='0.3',
+    version='0.4',
     url='',
     license='LGPLv3',
     author='Canonical Webteam',


### PR DESCRIPTION
when accessing a page like /index.html that path generated was: templates/index.html/index.html even when index.html exists because the code adds a `.html` to every path given to the function
By checking if the template exists we remove this problem.

You can try to access maas.io/index.html we get a 500